### PR TITLE
Remove ssl from asyncpg, doesnt seem needed

### DIFF
--- a/examples/asyncpg_items.py
+++ b/examples/asyncpg_items.py
@@ -23,9 +23,6 @@ async def async_main():
         POSTGRES_PASSWORD = os.environ["POSTGRES_PASSWORD"]
 
     DATABASE_URI = f"postgresql://{POSTGRES_USERNAME}:{POSTGRES_PASSWORD}@{POSTGRES_HOST}/{POSTGRES_DATABASE}"
-    # Specify SSL mode if needed
-    if POSTGRES_SSL := os.environ.get("POSTGRES_SSL"):
-        DATABASE_URI += f"?ssl={POSTGRES_SSL}"
 
     conn = await asyncpg.connect(DATABASE_URI)
 


### PR DESCRIPTION
This pull request includes a change in the `async def async_main():` function within the `examples/asyncpg_items.py` file. The change removes the SSL mode specification for the database connection, as it causes an error. It seems like asyncpg tries to do more autodetection of ssl and the query param causes a conflict.

fixes #6 